### PR TITLE
Changed the table.print function inside LuaExtensions.cs

### DIFF
--- a/ScribeBot/Wrappers/LuaExtensions.cs
+++ b/ScribeBot/Wrappers/LuaExtensions.cs
@@ -18,13 +18,48 @@ namespace ScribeBot.Wrappers
                 repeat until os.clock() > callTime
             end
 
-            function table.print(t)
-                print( '{' )
+            --[[
+            TABLE.PRINT(TABLE):
+                - Takes one argument (other two are for internal use).
+                - Recursively pretty prints a table, formatted with 'INDEX: [TYPE] VALUE'
+            ]]
+            function table.print(t, iteration, t_colon)
+            
+                -- Variable setup,
+                local iteration = iteration or 0
+                local t_colon = t_colon or ''
+                local count = 1
+                
+                -- Print initial `{`,
+                print(string.format('%' .. iteration * 2 .. 's{', ''))
+                
+                -- Loop through every element and print it accordingly,
                 for key, value in pairs(t) do
-                    print(string.format('\t%-20s= %s', tostring(key), tostring(value)))
+                    -- Test weather this is the last element, if so, remove colon,
+                    local colon = ','
+                    if count == #t then
+                    colon = ''
+                    end
+                    
+                    -- Check types, and print it accordingly,
+                    if type(value) == 'table' then
+                    table.print(value, iteration + 1, colon)
+                    elseif type(value) == 'string' then
+                    print(string.format('%' .. (iteration + 1) * 2 .. 's' .. key .. ': ' .. '[' .. type(value) .. '] \'' .. value .. '\'' .. colon, ''))
+                    elseif type(value) == 'number' then
+                    print(string.format('%' .. (iteration + 1) * 2 .. 's' .. key .. ': ' .. '[' .. type(value) .. '] ' .. value .. '' .. colon, ''))
+                    elseif type(value) == 'boolean' then
+                    print(string.format('%' .. (iteration + 1) * 2 .. 's' .. key .. ': ' .. '[' .. type(value) .. '] ' .. tostring(value) .. '' .. colon, ''))
+                    else
+                    print(string.format('%' .. (iteration + 1) * 2 .. 's' .. key .. ': ' .. '[' .. type(value) .. '] ' .. tostring(value) .. '' .. colon, ''))
+                    end
+                    count = count + 1
                 end
-                print( '}' )
+                
+                -- Print last `}`,
+                print(string.format('%' .. iteration * 2 .. 's}' .. t_colon, ''))
+                
             end
-        ";
+
     }
 }


### PR DESCRIPTION
**Hey,**
feel free to look through the changes, seems like it would work to me, tested the _Lua_ in [repl.it](https://repl.it), don't know if I've put it in correctly as I can't test the project itself, I trust however that you'll do this.

This is how it looks:
### Executing the function
```Lua
local tbl = {'abc', 'def', 123, {"Hello,", "World!", {1, 2, 3}}}
```

### Output
```Lua
{	
  1: [string] 'abc',	
  2: [string] 'def',	
  3: [number] 123,	
  {	
    1: [string] 'Hello,',	
    2: [string] 'World!',	
    {	
      1: [number] 1,	
      2: [number] 2,	
      3: [number] 3	
    }	
  }	
}
```

### The format
Tables are effectively represented as `\n{\n ... \n}\n` with `...` referring to the content inside.
Everything else follows this format `INDEX: [TYPE] VALUE`. Strings have `"..."` around them.

First pull request ever!

To try a little [demo](https://repl.it/repls/TrainedFamiliarRedundancy).

<sub>Timestamp: `11:47PM 12/04/2018` (Australian format & time)</sub>